### PR TITLE
fix: Add description for `ClientError`

### DIFF
--- a/Sources/ProseCoreFFI/Errors+Description.swift
+++ b/Sources/ProseCoreFFI/Errors+Description.swift
@@ -1,0 +1,16 @@
+//
+// This file is part of prose-app-macos.
+// Copyright (c) 2023 Prose Foundation
+//
+
+import Foundation
+
+extension ClientError: LocalizedError {
+  /// - Important: ``ClientError`` is not localized.
+  public var errorDescription: String? {
+    switch self {
+    case .Generic(let msg):
+      return msg
+    }
+  }
+}


### PR DESCRIPTION
When trying to log into Prose macOS, I'm getting `The operation couldn’t be completed. (ProseCoreFFI.ClientError error 0.)`:

<img width="440" alt="Screenshot 2023-05-30 at 13 19 43" src="https://github.com/prose-im/prose-wrapper-swift/assets/37386490/829394cc-3e8e-4c83-8b20-5ca805735f83">

Users should not see this, and it doesn't help debugging, so I believe it's better if we add `LocalizedError` conformance as a quick win.

Ideally `ClientError` should be localized, but it's an issue for another time.